### PR TITLE
Fix popWaitersList waiter leak on cancellation

### DIFF
--- a/bloque.go
+++ b/bloque.go
@@ -142,7 +142,7 @@ func (q *Bloque) Pop(ctx context.Context) (item interface{}, err error) {
 			waitChan: make(chan interface{}),
 			waiting:  true,
 		}
-		q.popWaitersList.PushBack(waiterItem)
+		waiterListElement := q.popWaitersList.PushBack(waiterItem)
 		q.mutex.Unlock()
 
 		select {
@@ -160,6 +160,9 @@ func (q *Bloque) Pop(ctx context.Context) (item interface{}, err error) {
 				q.mutex.Unlock()
 			} else {
 				waiterItem.mutex.Unlock()
+				q.mutex.Lock()
+				q.popWaitersList.Remove(waiterListElement)
+				q.mutex.Unlock()
 			}
 			return nil, ctx.Err()
 		}


### PR DESCRIPTION
See issue https://github.com/technicianted/bloque/issues/1 :

When the context is canceled, the waiterItem is added to the popWaitersList, but never removed, even though the Pop() is not awaited anymore

Resolves #1 